### PR TITLE
add setter for extended data

### DIFF
--- a/Entity/PaymentInstruction.php
+++ b/Entity/PaymentInstruction.php
@@ -120,6 +120,11 @@ class PaymentInstruction implements PaymentInstructionInterface
         return $this->extendedData;
     }
 
+    public function setExtendedData(ExtendedData $data)
+    {
+        return $this->extendedData = $data;
+    }
+
     public function getState()
     {
         return $this->state;


### PR DESCRIPTION
I need a way to set cancel and return urls after I know paymentId. 
The _Router_ requires it as a pramater for url generation.

The solution I found is to add _setExtendedData_ to _PaymentInstruction_ model.

Is there a better way to do such things?

My example:

```
    $instruction = new PaymentInstruction(100, 'EUR', 'paypal_express_checkout', new ExtendedData());
    $ppc->createPaymentInstruction($instruction);

    $paymentId = $ppc->createPayment($instruction->getId(), 100)->getId();

    $paymentUrl = $router->generate('payment', array('paymentId' => $paymentId), true);

    $extendedData = new ExtendedData();
    $extendedData->set('return_url', $paymentUrl);
    $extendedData->set('cancel_url', $paymentUrl);
    $instruction->setExtendedData($extendedData);
    $em->flush($instruction);

    // redirect to payment action 
    //return new RedirectResponse($paymentUrl, 302);
```

Thanks!
