### PR TITLE
fix schema validation

### DIFF
--- a/Resources/config/doctrine/Credit.orm.xml
+++ b/Resources/config/doctrine/Credit.orm.xml
@@ -24,7 +24,7 @@
             </cascade>
         </one-to-many>
         
-        <many-to-one field="paymentInstruction" target-entity="PaymentInstruction">
+        <many-to-one field="paymentInstruction" target-entity="PaymentInstruction" inversed-by="credits">
             <join-column name="payment_instruction_id" 
                          referenced-column-name="id" 
                          nullable="false" 


### PR DESCRIPTION
There is a validation error.

The field JMS\Payment\CoreBundle\Entity\PaymentInstruction#credits is on the inverse side of a bi-directional relationship,
but the specified mappedBy association on the target-entity JMS\Payment\CoreBundle\Entity\Credit#paymentInstruction
does not contain the required \'inversedBy\' attribute.
