### PR TITLE
[docs] Tweak to usage doc to fix return_url and cancel_url

### DIFF
--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -124,10 +124,10 @@ which we will leverage.
                     'paypal_express_checkout' => array(
                         'return_url' => $this->router->generate('payment_complete', array(
                             'orderNumber' => $order->getOrderNumber(),
-                        )),
+                        ), true),
                         'cancel_url' => $this->router->generate('payment_cancel', array(
                             'orderNumber' => $order->getOrderNumber(),
-                        ))
+                        ), true)
                     ),
                 ),
             ));


### PR DESCRIPTION
Tweaked the url generation in the `detailsAction` as Im fairly sure it needs to be absolute, not relative. 

Finally got it all working once I made this change.

Without this paypal returns 10471 or 10472 indicating missing return url or missing cancel url respectively.
