### PR TITLE
Fix compatibility with interface FormTypeInterface

### DIFF
--- a/Form/ChoosePaymentMethodType.php
+++ b/Form/ChoosePaymentMethodType.php
@@ -159,7 +159,7 @@ class ChoosePaymentMethodType extends AbstractType
         }
     }
 
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         return array(
             'currency'        => null,


### PR DESCRIPTION
Fixed Form/ChoosePaymentMethodType for compatibility with Symfony\Component\Form\AbstractType (the getDefaultOptions method)
