### PR TITLE
Exception being thrown when trying to save extendedData to unpersisted financialTransaction

### DIFF
--- a/Entity/FinancialTransaction.php
+++ b/Entity/FinancialTransaction.php
@@ -140,7 +140,10 @@ class FinancialTransaction implements FinancialTransactionInterface
     {
         $this->updatedAt = new \DateTime;
 
-        if (null !== $this->extendedData && false === $this->extendedData->equals($this->extendedDataOriginal)) {
+        if ( null !== $this->extendedDataOriginal &&
+             null !== $this->extendedData && 
+             false === $this->extendedData->equals($this->extendedDataOriginal)
+        ){
             $this->extendedData = clone $this->extendedData;
         }
     }


### PR DESCRIPTION
I am finding that when trying to set extendedData on a financialTransaction that has not yet been persisted (so we are setting extended data at the time we are creating the financial transaction) then an exception is thrown (due to the call to $this->extendedData->equals($this->extendedDataOriginal) which does not accept a null param).

The extendedDataOriginal property is not set (because the entity has not been loaded, the onPostLoad() event is not being called).
