### PR TITLE
Changed QueryablePlugin reference in PluginController to QueryablePlugin...

### DIFF
--- a/PluginController/PluginController.php
+++ b/PluginController/PluginController.php
@@ -144,7 +144,7 @@ abstract class PluginController implements PluginControllerInterface
     {
         $plugin = $this->getPlugin($instruction->getPaymentSystemName());
 
-        if (!$plugin instanceof QueryablePlugin) {
+        if (!$plugin instanceof QueryablePluginInterface) {
             return null;
         }
 


### PR DESCRIPTION
Hi Johannes,

The check within PluginController::getRemainingValueOnPaymentInstruction() should be looking for an instance of QueryablePluginInterface and not QueryablePlugin.

If you agree then please accept this pull request.

Many thanks
Barry
