### PR TITLE
Attach exception to the Response object when handling FinancialException

### DIFF
--- a/PluginController/PluginController.php
+++ b/PluginController/PluginController.php
@@ -263,7 +263,9 @@ abstract class PluginController implements PluginControllerInterface
 
             $this->dispatchPaymentStateChange($payment, $oldState);
 
-            return $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result->setPluginException($ex);
+            return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
 
@@ -388,7 +390,9 @@ abstract class PluginController implements PluginControllerInterface
 
             $this->dispatchPaymentStateChange($payment, $oldState);
 
-            return $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result->setPluginException($ex);
+            return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
 
@@ -557,7 +561,9 @@ abstract class PluginController implements PluginControllerInterface
                 $payment->setCreditingAmount($payment->getCreditingAmount() - $amount);
             }
 
-            return $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result->setPluginException($ex);
+            return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
 
@@ -679,7 +685,9 @@ abstract class PluginController implements PluginControllerInterface
 
             $this->dispatchPaymentStateChange($payment, $oldState);
 
-            return $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result->setPluginException($ex);
+            return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
 
@@ -783,7 +791,9 @@ abstract class PluginController implements PluginControllerInterface
             $payment->setReversingApprovedAmount(0.0);
             $instruction->setReversingApprovedAmount($instruction->getReversingApprovedAmount() - $amount);
 
-            return $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result->setPluginException($ex);
+            return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
 
@@ -917,7 +927,9 @@ abstract class PluginController implements PluginControllerInterface
                 $payment->setReversingCreditedAmount($payment->getReversingCreditedAmount() - $amount);
             }
 
-            return $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result->setPluginException($ex);
+            return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
 
@@ -1013,7 +1025,9 @@ abstract class PluginController implements PluginControllerInterface
         } catch (PluginFinancialException $ex) {
             $transaction->setState(FinancialTransactionInterface::STATE_FAILED);
 
-            return $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
+            $result->setPluginException($ex);
+            return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
 

--- a/PluginController/PluginController.php
+++ b/PluginController/PluginController.php
@@ -265,6 +265,7 @@ abstract class PluginController implements PluginControllerInterface
 
             $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
             $result->setPluginException($ex);
+			
             return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
@@ -392,6 +393,7 @@ abstract class PluginController implements PluginControllerInterface
 
             $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
             $result->setPluginException($ex);
+			
             return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
@@ -563,6 +565,7 @@ abstract class PluginController implements PluginControllerInterface
 
             $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
             $result->setPluginException($ex);
+			
             return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
@@ -687,6 +690,7 @@ abstract class PluginController implements PluginControllerInterface
 
             $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
             $result->setPluginException($ex);
+			
             return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
@@ -793,6 +797,7 @@ abstract class PluginController implements PluginControllerInterface
 
             $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
             $result->setPluginException($ex);
+			
             return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
@@ -929,6 +934,7 @@ abstract class PluginController implements PluginControllerInterface
 
             $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
             $result->setPluginException($ex);
+			
             return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
@@ -1027,6 +1033,7 @@ abstract class PluginController implements PluginControllerInterface
 
             $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_FAILED, $transaction->getReasonCode());
             $result->setPluginException($ex);
+			
             return $result;
         } catch (PluginBlockedException $blocked) {
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);


### PR DESCRIPTION
Is there any reason why the exception is not attached to the Response object? 
It would be nice to make this change because of displaying error description from the exception to the user.