### PR TITLE
Add ext-mcrypt to the require section of composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0,<2.2-dev"
+        "symfony/framework-bundle": ">=2.0,<2.2-dev",
+        "ext-mcrypt": "*"
     },
     "recommend": {
         "doctrine/doctrine-bundle": "dev-master"


### PR DESCRIPTION
Hi,

I discovered while deploying that the bundle needs the php mcrypt extension.
So here it is in the composer.json require section.

BTW: Thanks for this bundle ;-)
