### PR TITLE
Removes the no longer used choice strategies from the FormType

### DIFF
--- a/Form/ChoosePaymentMethodType.php
+++ b/Form/ChoosePaymentMethodType.php
@@ -63,8 +63,6 @@ class ChoosePaymentMethodType extends AbstractType
         $builder->add('method', 'choice', array(
             'choices' => $this->buildChoices($options['available_methods']),
             'expanded' => true,
-            'index_strategy' => ChoiceList::COPY_CHOICE,
-            'value_strategy' => ChoiceList::COPY_CHOICE,
         ));
 
         foreach ($options['available_methods'] as $method) {


### PR DESCRIPTION
With them still in:

Fatal error: Undefined class constant 'COPY_CHOICE' in /Users/tim/Sites/ibms.tim/vendor/jms/payment-core-bundle/JMS/Payment/CoreBundle/Form/ChoosePaymentMethodType.php on line 66
