### PR TITLE
An approve and deposit should result in the state changing to deposited ...

### DIFF
--- a/PluginController/PluginController.php
+++ b/PluginController/PluginController.php
@@ -348,7 +348,7 @@ abstract class PluginController implements PluginControllerInterface
                 $transaction->setState(FinancialTransactionInterface::STATE_SUCCESS);
                 $processedAmount = $transaction->getProcessedAmount();
 
-                $payment->setState(PaymentInterface::STATE_APPROVED);
+                $payment->setState(PaymentInterface::STATE_DEPOSITED);
                 $payment->setApprovingAmount(0.0);
                 $payment->setDepositingAmount(0.0);
                 $payment->setApprovedAmount($processedAmount);


### PR DESCRIPTION
Hi Johannes,

The PluginController::doApproveAndDeposit function should have a successful state of PaymentInterface::STATE_DEPOSITED and not PaymentInterface::STATE_APPROVED ,  do you agree?

If so could you accept this pull request.

If not I will need to opt to use PluginController::doDeposit  to end up with a deposited state.

Many thanks
Barry
