### PR TITLE
Updated the Choose FormType to match upstream.

### DIFF
--- a/Form/ChoosePaymentMethodType.php
+++ b/Form/ChoosePaymentMethodType.php
@@ -159,7 +159,7 @@ class ChoosePaymentMethodType extends AbstractType
         }
     }
 
-    public function getDefaultOptions()
+    public function getDefaultOptions(array $options)
     {
         return array(
             'amount'          => null,


### PR DESCRIPTION
I only updated to match the abstract class.

composer.json indicates that you support >=2.0<2.2, except I dont think 2.0 will have worked for a while now? If you're okay with dropping 2.0 (since 2.0 wouldnt have worked anyway?), I'll update the FormType to use setDefaultOptions instead.
