### PR TITLE
added explicit addTransaction call in PluginController::doApprove

### DIFF
--- a/PluginController/PluginController.php
+++ b/PluginController/PluginController.php
@@ -211,6 +211,7 @@ abstract class PluginController implements PluginControllerInterface
             $transaction->setPayment($payment);
             $transaction->setTransactionType(FinancialTransactionInterface::TRANSACTION_TYPE_APPROVE);
             $transaction->setRequestedAmount($amount);
+            $payment->addTransaction($transaction);
 
             $payment->setState(PaymentInterface::STATE_APPROVING);
             $payment->setApprovingAmount($amount);

--- a/Tests/PluginController/PluginControllerTest.php
+++ b/Tests/PluginController/PluginControllerTest.php
@@ -596,6 +596,7 @@ class PluginControllerTest extends \PHPUnit_Framework_TestCase
         $result = $this->callApprove($controller, array($payment, 100));
 
         $this->assertSame($transaction, $result->getFinancialTransaction());
+        $this->assertSame($transaction, $payment->getApproveTransaction());
         $this->assertInstanceOf('JMS\Payment\CoreBundle\PluginController\Result', $result);
         $this->assertTrue(PluginInterface::RESPONSE_CODE_SUCCESS === $transaction->getResponseCode());
         $this->assertSame(PluginInterface::RESPONSE_CODE_SUCCESS, $transaction->getResponseCode());


### PR DESCRIPTION
The call is made within the doApproveAndDeposit method, but not the doApprove method at present, so correcting this.
