### PR TITLE
made approve and deposit actions in plugin controller result as deposited

### DIFF
--- a/PluginController/PluginController.php
+++ b/PluginController/PluginController.php
@@ -349,7 +349,7 @@ abstract class PluginController implements PluginControllerInterface
                 $transaction->setState(FinancialTransactionInterface::STATE_SUCCESS);
                 $processedAmount = $transaction->getProcessedAmount();
 
-                $payment->setState(PaymentInterface::STATE_APPROVED);
+                $payment->setState(PaymentInterface::STATE_DEPOSITED);
                 $payment->setApprovingAmount(0.0);
                 $payment->setDepositingAmount(0.0);
                 $payment->setApprovedAmount($processedAmount);

--- a/Tests/PluginController/PluginControllerTest.php
+++ b/Tests/PluginController/PluginControllerTest.php
@@ -342,7 +342,7 @@ class PluginControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($transaction, $result->getFinancialTransaction());
         $this->assertSame(Result::STATUS_SUCCESS, $result->getStatus());
         $this->assertSame(PluginInterface::REASON_CODE_SUCCESS, $result->getReasonCode());
-        $this->assertSame(PaymentInterface::STATE_APPROVED, $payment->getState());
+        $this->assertSame(PaymentInterface::STATE_DEPOSITED, $payment->getState());
         $this->assertEquals(0, $payment->getApprovingAmount());
         $this->assertEquals(0, $payment->getDepositingAmount());
         $this->assertEquals(50, $payment->getApprovedAmount());
@@ -387,7 +387,7 @@ class PluginControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($transaction, $result->getFinancialTransaction());
         $this->assertSame(Result::STATUS_SUCCESS, $result->getStatus());
         $this->assertSame(PluginInterface::REASON_CODE_SUCCESS, $result->getReasonCode());
-        $this->assertSame(PaymentInterface::STATE_APPROVED, $payment->getState());
+        $this->assertSame(PaymentInterface::STATE_DEPOSITED, $payment->getState());
         $this->assertEquals(0, $payment->getApprovingAmount());
         $this->assertEquals(0, $payment->getDepositingAmount());
         $this->assertEquals(50, $payment->getApprovedAmount());


### PR DESCRIPTION
This includes the change in #58, but with updated tests.
