### PR TITLE
Add ETSPaymentDotpayBundle

### DIFF
--- a/Resources/doc/payment_backends.rst
+++ b/Resources/doc/payment_backends.rst
@@ -8,7 +8,8 @@ Available Payment Backends
 This is an incomplete list of implemented payment backends:
 
 - Paypal: JMSPaymentPaypalBundle_
+- Dotpay: ETSPaymentDotpayBundle_
 
 
 .. _JMSPaymentPaypalBundle: http://jmsyst.com/bundles/JMSPaymentPaypalBundle
-
+.. _ETSPaymentDotpayBundle: https://github.com/ETSGlobal/ETSPaymentDotpayBundle


### PR DESCRIPTION
Hi,

We are using the CoreBundle here at ETSGlobal and we have implemented the DotpayBundle recently. Can you have a look on it and add this backend to the list ?

Thanks.

(For the record : ETSPaymentOgoneBundle backend is on development stage but will be available soon)
