### PR TITLE
Added parameter and method to the VisitUrl object

### DIFF
--- a/Plugin/Exception/Action/VisitUrl.php
+++ b/Plugin/Exception/Action/VisitUrl.php
@@ -18,17 +18,62 @@ namespace JMS\Payment\CoreBundle\Plugin\Exception\Action;
  * limitations under the License.
  */
 
+/**
+ * VisitUrl action
+ *
+ * Parameter of an ActionRequiredException, it allow the user to catch
+ * this case and redirect the user to this target url
+ */
 class VisitUrl
 {
+    /**
+     * @var string
+     */
     protected $url;
 
-    public function __construct($url)
+    /**
+     * @var string
+     */
+    protected $method;
+
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * @param string $url
+     * @param string $method
+     * @param array  $parameters
+     */
+    public function __construct($url, $method = 'GET', array $parameters = array())
     {
         $this->url = $url;
+        $this->parameters = $parameters;
+        $this->method = $method;
     }
 
+    /**
+     * @return string
+     */
     public function getUrl()
     {
         return $this->url;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
     }
 }


### PR DESCRIPTION
Hi Johannes,

I needed to add POST parameters to the VisitUrl for Ogone and Dotpay (Dotpay allows GET parameters but it can generate a 414 (Request-URI Too Long) status). I added a "method" parameter too.
