### PR TITLE
declared bundle as allowing symfony dependencies for all versions of 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0,<2.3-dev",
+        "symfony/framework-bundle": ">=2.0,<3.0",
         "ext-mcrypt": "*"
     },
     "require-dev": {
@@ -34,8 +34,8 @@
         "jms/di-extra-bundle": "*"
     },
     "suggest": {
-        "symfony/form": ">=2.1,<2.2-dev",
-        "symfony/validator": ">=2.1,<2.2-dev"
+        "symfony/form": ">=2.1,<3.0",
+        "symfony/validator": ">=2.1,<3.0"
     },
     "autoload": {
         "psr-0": { "JMS\\Payment\\CoreBundle": "" }


### PR DESCRIPTION
It should be possible now for the bundle to be compatible with all remaining versions of Symfony 2.x, and this change declares the dependencies as such.
