### PR TITLE
Bugfix mcrypt rtrim null bytes on decryption

### DIFF
--- a/Cryptography/MCryptEncryptionService.php
+++ b/Cryptography/MCryptEncryptionService.php
@@ -77,7 +77,7 @@ class MCryptEncryptionService implements EncryptionServiceInterface
         $encryptedValue = base64_decode($encryptedValue);
         $iv = substr($encryptedValue, 0, $size);
 
-        return rtrim(mcrypt_decrypt($this->cipher, $this->key, substr($encryptedValue, $size), $this->mode, $iv));
+        return rtrim(mcrypt_decrypt($this->cipher, $this->key, substr($encryptedValue, $size), $this->mode, $iv), "\0");
     }
 
     /**


### PR DESCRIPTION
If you have longer strings to encrypt and later decrypt, the null-bytes from encryption are left in string and causes problemes while decryption.

See php docs http://www.php.net/manual/en/function.mcrypt-generic.php for details:
... use rtrim($str, "\0") to remove the padding.