### PR TITLE
Allow to override rollback implementation of the EntityPluginController.

### DIFF
--- a/PluginController/EntityPluginController.php
+++ b/PluginController/EntityPluginController.php
@@ -67,8 +67,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->entityManager->getConnection()->rollback();
-            $this->entityManager->close();
+            $this->doRollback();
 
             throw $failure;
         }
@@ -94,8 +93,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->entityManager->getConnection()->rollback();
-            $this->entityManager->close();
+            $this->doRollback();
 
             throw $failure;
         }
@@ -126,8 +124,7 @@ class EntityPluginController extends PluginController
 
             return $credit;
         } catch (\Exception $failure) {
-            $this->entityManager->getConnection()->rollback();
-            $this->entityManager->close();
+            $this->doRollback();
 
             throw $failure;
         }
@@ -149,8 +146,7 @@ class EntityPluginController extends PluginController
 
             return $credit;
         } catch (\Exception $failure) {
-            $this->entityManager->getConnection()->rollback();
-            $this->entityManager->close();
+            $this->doRollback();
 
             throw $failure;
         }
@@ -183,8 +179,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->entityManager->getConnection()->rollback();
-            $this->entityManager->close();
+            $this->doRollback();
 
             throw $failure;
         }
@@ -210,8 +205,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->entityManager->getConnection()->rollback();
-            $this->entityManager->close();
+            $this->doRollback();
 
             throw $failure;
         }
@@ -288,8 +282,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->entityManager->getConnection()->rollback();
-            $this->entityManager->close();
+            $this->doRollback();
 
             throw $failure;
         }
@@ -312,8 +305,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->entityManager->getConnection()->rollback();
-            $this->entityManager->close();
+            $this->doRollback();
 
             throw $failure;
         }
@@ -397,5 +389,11 @@ class EntityPluginController extends PluginController
         }
 
         return $paymentInstruction;
+    }
+
+    protected function doRollback()
+    {
+        $this->entityManager->getConnection()->rollback();
+        $this->entityManager->close();
     }
 }

--- a/PluginController/EntityPluginController.php
+++ b/PluginController/EntityPluginController.php
@@ -67,9 +67,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->doRollback();
-
-            throw $failure;
+            $this->doRollback($failure);
         }
     }
 
@@ -93,9 +91,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->doRollback();
-
-            throw $failure;
+            $this->doRollback($failure);
         }
     }
 
@@ -124,9 +120,7 @@ class EntityPluginController extends PluginController
 
             return $credit;
         } catch (\Exception $failure) {
-            $this->doRollback();
-
-            throw $failure;
+            $this->doRollback($failure);
         }
     }
 
@@ -146,9 +140,7 @@ class EntityPluginController extends PluginController
 
             return $credit;
         } catch (\Exception $failure) {
-            $this->doRollback();
-
-            throw $failure;
+            $this->doRollback($failure);
         }
     }
 
@@ -179,9 +171,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->doRollback();
-
-            throw $failure;
+            $this->doRollback($failure);
         }
     }
 
@@ -205,9 +195,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->doRollback();
-
-            throw $failure;
+            $this->doRollback($failure);
         }
     }
 
@@ -282,9 +270,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->doRollback();
-
-            throw $failure;
+            $this->doRollback($failure);
         }
     }
 
@@ -305,9 +291,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->doRollback();
-
-            throw $failure;
+            $this->doRollback($failure);
         }
     }
 
@@ -328,10 +312,7 @@ class EntityPluginController extends PluginController
 
             return $result;
         } catch (\Exception $failure) {
-            $this->entityManager->getConnection()->rollback();
-            $this->entityManager->close();
-
-            throw $failure;
+            $this->doRollback($failure);
         }
     }
 
@@ -391,9 +372,11 @@ class EntityPluginController extends PluginController
         return $paymentInstruction;
     }
 
-    protected function doRollback()
+    protected function doRollback(\Exception $failure)
     {
         $this->entityManager->getConnection()->rollback();
         $this->entityManager->close();
+
+        throw $failure;
     }
 }

--- a/PluginController/EntityPluginController.php
+++ b/PluginController/EntityPluginController.php
@@ -375,7 +375,6 @@ class EntityPluginController extends PluginController
     protected function doRollback(\Exception $failure)
     {
         $this->entityManager->getConnection()->rollback();
-        $this->entityManager->close();
 
         throw $failure;
     }


### PR DESCRIPTION
When a exception `FunctionNotSupportedException` was thrown from the `EntityPluginController`
I'd like to call another function.