### PR TITLE
Update documentation plugins with debug argument

### DIFF
--- a/Resources/doc/plugins.rst
+++ b/Resources/doc/plugins.rst
@@ -209,6 +209,7 @@ Now, we need to wire the form type with the dependency injection container:
         services:
             credit_card_type:
                 class: CreditCardType
+                arguments: [%kernel.debug%]
                 tags:
                     - { name: form.type, alias: credit_card }
                     - { name: payment.method_type }


### PR DESCRIPTION
A PluginType (in the docs for example CreditCardType) extends JMS\Payment\CoreBundle\Plugin\AbstractPlugin. AbstractPlugin has a constructor in which the debug variable is saved. This is useful information when developing your own plugin, and should therefore also be in the service definition.