### PR TITLE
Fix/tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
+  - 5.6
 
 before_script:
     - curl -s http://getcomposer.org/installer | php

--- a/Tests/Functional/PaymentWorkflowTest.php
+++ b/Tests/Functional/PaymentWorkflowTest.php
@@ -30,7 +30,8 @@ class PaymentWorkflowTest extends BaseTestCase
         $response = $client->getResponse();
         $this->assertSame(201, $response->getStatusCode(), substr($response, 0, 2000));
 
-        $em->refresh($order);
+        $em->clear();
+        $order = $em->getRepository('TestBundle:Order')->find($order->getId());
         $this->assertTrue(Number::compare(123.45, $order->getPaymentInstruction()->getAmount(), '=='));
         $this->assertEquals('bar', $order->getPaymentInstruction()->getExtendedData()->get('foo'));
     }

--- a/Tests/Plugin/GatewayPluginTest.php
+++ b/Tests/Plugin/GatewayPluginTest.php
@@ -20,7 +20,6 @@ class GatewayPluginTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(file_get_contents(__DIR__.'/Fixtures/sampleResponse'), $response->getContent());
         $this->assertEquals(200, $response->getStatus());
-        $this->assertEquals('200 OK', $response->getHeader('Status'));
     }
 
     protected function getPlugin()

--- a/Tests/Plugin/GatewayPluginTest.php
+++ b/Tests/Plugin/GatewayPluginTest.php
@@ -15,7 +15,7 @@ class GatewayPluginTest extends \PHPUnit_Framework_TestCase
         $plugin = $this->getPlugin();
 
         // not sure if there is a better approach to testing this
-        $request = new Request('https://raw.github.com/schmittjoh/JMSPaymentCoreBundle/master/Tests/Plugin/Fixtures/sampleResponse', 'GET');
+        $request = new Request('https://raw.githubusercontent.com/schmittjoh/JMSPaymentCoreBundle/master/Tests/Plugin/Fixtures/sampleResponse', 'GET');
         $response = $plugin->request($request);
 
         $this->assertEquals(file_get_contents(__DIR__.'/Fixtures/sampleResponse'), $response->getContent());


### PR DESCRIPTION
As mentioned in #133, tests have been failing on travis since [2013-12-09](https://travis-ci.org/schmittjoh/JMSPaymentCoreBundle/jobs/15185672):

    Class 'Symfony\Component\ExpressionLanguage\ExpressionLanguage' not found in
    (...)/vendor/symfony/security-core/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php on line 22

I wasn't able to reproduce this issue in specific. However, after fixing seemingly unrelated issues when running the tests locally the travis build started passing. 