### PR TITLE
Require needed dependencies only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ before_install:
   - if [[ $(phpenv version-name) == 5.3 ]]; then echo "memory_limit=-1" >> ~/.phpenv/versions/5.3/etc/conf.d/travis.ini; fi
 
 install: composer update --prefer-dist
+script: vendor/bin/phpunit

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -4,7 +4,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 
 // Composer
 if (file_exists(__DIR__.'/../vendor/autoload.php')) {
-    $loader = require_once __DIR__.'/../vendor/autoload.php';
+    $loader = require __DIR__.'/../vendor/autoload.php';
 
     AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
 

--- a/composer.json
+++ b/composer.json
@@ -9,33 +9,40 @@
         {
             "name": "Johannes M. Schmitt",
             "email": "schmittjoh@gmail.com"
+        },
+        {
+            "name": "Contributors",
+            "homepage": "https://github.com/schmittjoh/JMSPaymentCoreBundle/contributors"
         }
     ],
     "require": {
         "php": ">=5.3.2",
+        "ext-mcrypt": "*",
+        "doctrine/common": "~2.3",
         "doctrine/dbal": "~2.3",
-        "symfony/framework-bundle": "~2.0",
-        "ext-mcrypt": "*"
+        "doctrine/orm": "~2.3",
+        "symfony/browser-kit": "~2.0",
+        "symfony/config": "~2.0",
+        "symfony/dependency-injection": "~2.0",
+        "symfony/event-dispatcher": "~2.0",
+        "symfony/form": "~2.0",
+        "symfony/options-resolver": "~2.0",
+        "symfony/http-foundation": "~2.0",
+        "symfony/http-kernel": "~2.0",
+        "symfony/validator": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8|~5.4",
-        "symfony/class-loader": "~2.0",
-        "symfony/twig-bundle": "~2.0",
-        "symfony/finder": "~2.0",
-        "symfony/browser-kit": "~2.0",
-        "symfony/css-selector": "~2.0",
-        "symfony/form": "~2.0",
-        "symfony/validator": "~2.0",
-        "symfony/process": "~2.0",
-        "symfony/routing": "~2.0",
-        "symfony/twig-bridge": "~2.0",
-        "symfony/yaml": "~2.0",
-        "sensio/framework-extra-bundle": "~3.0",
         "doctrine/doctrine-bundle": "~1.6",
-        "doctrine/orm": "~2.4",
-        "jms/payment-paypal-bundle": "~1.0",
         "jms/aop-bundle": "~1.2",
-        "jms/di-extra-bundle": "~1.7"
+        "jms/di-extra-bundle": "~1.7",
+        "jms/payment-paypal-bundle": "~1.0",
+        "sensio/framework-extra-bundle": "~3.0",
+        "symfony/dom-crawler": "~2.0",
+        "symfony/framework-bundle": "~2.0",
+        "symfony/routing": "~2.0",
+        "symfony/twig-bundle": "~2.0",
+        "symfony/twig-bridge": "~2.0"
     },
     "autoload": {
         "psr-0": { "JMS\\Payment\\CoreBundle": "" }


### PR DESCRIPTION
Only require dependencies that are actually needed.

In addition, explicitly require `doctrine/common`, which would otherwise not be installed on PHP 5.3. This is a requirement for schmittjoh/JMSPaymentPaypalBundle#77, which is itself a requirement for #175.