### PR TITLE
Make encryption optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
     - Added missing `mayBePersisted` method
     - Added missing `$persist` parameter to `set` method
 - `JMS\Payment\CoreBundle\EntityExtendedDataType::convertToDatabaseValue` now throws an exception when attempting to convert an object which does not implement `JMS\Payment\CoreBundle\Model\ExtendedDataInterface`.
+- Encryption is now optional and disabled by default, unless the `secret` configuration option is set. This ensures existing installations keep working as expected.
 
 ### Deprecated
 - The service `payment.encryption_service` has been deprecated and is now an alias to `payment.crypto.mcrypt`. Parameters specified for `payment.encryption_service` are automatically set for `payment.crypto.mcrypt` so no changes are required in service configuration until `payment.encryption_service` is removed in 2.0.
+- The `secret` configuration option has been deprecated in favor of `encryption.secret` and will be removed in 2.0.
 
 ## [1.2.0] - 2016-10-03
 ### Added

--- a/DependencyInjection/Compiler/LegacyCryptoPass.php
+++ b/DependencyInjection/Compiler/LegacyCryptoPass.php
@@ -49,7 +49,7 @@ class LegacyCryptoPass implements CompilerPassInterface
                 $container->setParameter('payment.crypto.mcrypt.'.$parameter, $modernValue);
             } elseif ($legacyValue !== $defaultValue) {
                 $container->setParameter('payment.crypto.mcrypt.'.$parameter, $legacyValue);
-                @trigger_error('payment.encryption_service.'.$parameter.' has been deprecated in favor of payment.crypto.mcrypt.'.$parameter.' and will be removed in 2.0', E_USER_NOTICE);
+                @trigger_error('payment.encryption_service.'.$parameter.' has been deprecated in favor of payment.crypto.mcrypt.'.$parameter.' and will be removed in 2.0', E_USER_DEPRECATED);
             }
         }
     }

--- a/Entity/ExtendedDataType.php
+++ b/Entity/ExtendedDataType.php
@@ -62,7 +62,7 @@ class ExtendedDataType extends ObjectType
             $value = $extendedData->get($name);
             $isEncryptionRequired = $extendedData->isEncryptionRequired($name);
 
-            if ($isEncryptionRequired) {
+            if ($isEncryptionRequired && self::$encryptionService) {
                 $value = self::$encryptionService->encrypt(serialize($value));
             }
 
@@ -94,7 +94,7 @@ class ExtendedDataType extends ObjectType
             $isEncryptionRequired = (bool) $value[1];
             $value = $value[0];
 
-            if ($isEncryptionRequired) {
+            if ($isEncryptionRequired && self::$encryptionService) {
                 $value = unserialize(self::$encryptionService->decrypt($value));
             }
 

--- a/JMSPaymentCoreBundle.php
+++ b/JMSPaymentCoreBundle.php
@@ -29,7 +29,9 @@ class JMSPaymentCoreBundle extends Bundle
 {
     public function boot()
     {
-        ExtendedDataType::setEncryptionService($this->container->get('payment.crypto.mcrypt'));
+        if ($this->container->has('payment.crypto.mcrypt')) {
+            ExtendedDataType::setEncryptionService($this->container->get('payment.crypto.mcrypt'));
+        }
     }
 
     public function build(ContainerBuilder $builder)

--- a/Resources/doc/setup.rst
+++ b/Resources/doc/setup.rst
@@ -43,12 +43,8 @@ And then use it in your configuration:
 
         # app/config/config.yml
         jms_payment_core:
-            secret: yoursecret
-
-    .. code-block :: xml
-
-        <!-- app/config/config.xml -->
-        <jms-payment-core secret="yoursecret" />
+            encryption:
+                secret: yoursecret
 
 .. note ::
 

--- a/Tests/DependencyInjection/Configuration/ConfigurationTest.php
+++ b/Tests/DependencyInjection/Configuration/ConfigurationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace JMS\Payment\CoreBundle\Tests\DependencyInjection\Configuration;
+
+use JMS\Payment\CoreBundle\DependencyInjection\Configuration;
+use Matthias\SymfonyConfigTest\PhpUnit\AbstractConfigurationTestCase;
+
+class ConfigurationTest extends AbstractConfigurationTestCase
+{
+    public function testNoSecret()
+    {
+        $this->assertConfigurationIsValid(array());
+        $this->assertConfigurationIsInvalid(array('secret' => ''));
+
+        $this->assertConfigurationEquals(
+            array(),
+            array('encryption' => array('enabled' => false))
+        );
+    }
+
+    public function testSecret()
+    {
+        $this->assertConfigurationIsValid(array('secret' => 'foo'));
+
+        $this->assertConfigurationEquals(
+            array('secret' => 'foo'),
+            array(
+                'secret' => 'foo',
+                'encryption' => array(
+                    'enabled' => true,
+                    'secret' => 'foo',
+                ),
+            )
+        );
+    }
+
+    public function testEncryptionDisabled()
+    {
+        $this->assertConfigurationIsValid(array());
+        $this->assertConfigurationIsValid(array('encryption' => false));
+
+        $this->assertConfigurationEquals(
+            array(),
+            array('encryption' => array(
+                'enabled' => false,
+            ))
+        );
+
+        $this->assertConfigurationEquals(
+            array('encryption' => false),
+            array('encryption' => array(
+                'enabled' => false,
+            ))
+        );
+
+        $this->assertConfigurationEquals(
+            array('encryption' => array(
+                'enabled' => false,
+            )),
+            array('encryption' => array(
+                'enabled' => false,
+            ))
+        );
+    }
+
+    public function testEncryptionEnabled()
+    {
+        $this->assertConfigurationIsInvalid(array('encryption' => true));
+
+        $this->assertConfigurationIsInvalid(array('encryption' => array(
+            'enabled' => true,
+        )));
+
+        $this->assertConfigurationIsValid(array('encryption' => array(
+            'enabled' => true,
+            'secret' => 'foo',
+        )));
+
+        $this->assertConfigurationEquals(
+            array('encryption' => array(
+                'enabled' => true,
+                'secret' => 'foo',
+            )),
+            array('encryption' => array(
+                'enabled' => true,
+                'secret' => 'foo',
+            ))
+        );
+    }
+
+    protected function getConfiguration()
+    {
+        return new Configuration('jms_payment_core');
+    }
+
+    protected function assertConfigurationIsInvalid(array $config, $expected = null, $useRegExp = false)
+    {
+        parent::assertConfigurationIsInvalid(array($config), $expected, $useRegExp);
+    }
+
+    protected function assertConfigurationIsValid(array $config, $breadcrumbPath = null)
+    {
+        parent::assertConfigurationIsValid(array($config), $breadcrumbPath);
+    }
+
+    protected function assertConfigurationEquals($config, $expected, $breadcrumbPath = null)
+    {
+        $this->assertProcessedConfigurationEquals($config, $expected, $breadcrumbPath);
+    }
+
+    protected function assertProcessedConfigurationEquals(array $config, array $expected, $breadcrumbPath = null)
+    {
+        parent::assertProcessedConfigurationEquals(array($config), $expected, $breadcrumbPath);
+    }
+}

--- a/Tests/Functional/PaymentWorkflowNoEncryptionTest.php
+++ b/Tests/Functional/PaymentWorkflowNoEncryptionTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace JMS\Payment\CoreBundle\Tests\Functional;
+
+class PaymentWorkflowNoEncryptionTest extends PaymentWorkflowTest
+{
+    protected static function createKernel(array $options = array())
+    {
+        return parent::createKernel(array('config' => 'config_no_encryption.yml'));
+    }
+}

--- a/Tests/Functional/SchemaTest.php
+++ b/Tests/Functional/SchemaTest.php
@@ -7,6 +7,9 @@ use JMS\Payment\CoreBundle\Util\Legacy;
 
 class SchemaTest extends BaseTestCase
 {
+    /**
+     * @runInSeparateProcess
+     */
     public function testLegacySchemaIsValid()
     {
         if (!Legacy::supportsSecureRandom()) {
@@ -18,6 +21,9 @@ class SchemaTest extends BaseTestCase
         $this->doTestSchemaIsValid();
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSchemaIsValid()
     {
         if (Legacy::supportsSecureRandom()) {
@@ -29,6 +35,9 @@ class SchemaTest extends BaseTestCase
         $this->doTestSchemaIsValid();
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     private function doTestSchemaIsValid()
     {
         $this->createClient();

--- a/Tests/Functional/config/config_no_encryption.yml
+++ b/Tests/Functional/config/config_no_encryption.yml
@@ -1,5 +1,2 @@
 imports:
     - { resource: default.yml }
-
-jms_payment_core:
-    secret: test

--- a/Tests/Functional/config/default.yml
+++ b/Tests/Functional/config/default.yml
@@ -1,0 +1,10 @@
+imports:
+    - { resource: doctrine.yml }
+    - { resource: framework.php }
+
+jms_payment_paypal:
+    username: schmit_1283340315_biz_api1.gmail.com
+    password: 1283340321
+    signature: A93vj6VJ.ZIRNjbI6GFgi4N2Km.5ATLs-EinlyWk2htEGX0xc3L8YIBo
+    return_url: http://paypal.test/payment
+    cancel_url: http://paypal.test/payment

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
         "symfony/templating": "~2.3|~3.0",
         "symfony/twig-bundle": "~2.3|~3.0",
         "symfony/twig-bridge": "~2.3|~3.0",
-        "twig/twig": "~1.0"
+        "twig/twig": "~1.0",
+        "matthiasnoback/symfony-config-test": "^2.1"
 
     },
     "autoload": {


### PR DESCRIPTION
Encryption is now optional and disabled by default, unless the `secret` configuration option is set. This ensures existing installations keep working as expected.

The reason for disabling encryption by default is in order for us to be able to use utility commands to setup encryption, for example, generating keys. This would not be possible if encryption would be enabled by default, in which case configuration validation would fail when trying to run the command.