### PR TITLE
Make defuse the default encryption provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
     - Added missing `mayBePersisted` method
     - Added missing `$persist` parameter to `set` method
 - `JMS\Payment\CoreBundle\EntityExtendedDataType::convertToDatabaseValue` now throws an exception when attempting to convert an object which does not implement `JMS\Payment\CoreBundle\Model\ExtendedDataInterface`.
-- Encryption is now optional and disabled by default, unless the `secret` configuration option is set. This ensures existing installations keep working as expected.
+- Encryption is now optional and disabled by default, unless the `secret` configuration option is set.
+- `defuse_php_encryption` is now the default encryption provider, unless when using the `secret` configuration option, in which case the default is set to `mcrypt`.
 
 ### Deprecated
 - The service `payment.encryption_service` has been deprecated and is now an alias to `payment.encryption.mcrypt`. Parameters specified for `payment.encryption_service` are automatically set for `payment.encryption.mcrypt` so no changes are required in service configuration until `payment.encryption_service` is removed in 2.0.
-- The `secret` configuration option has been deprecated in favor of `encryption.secret` and will be removed in 2.0.
+- The `secret` configuration option has been deprecated in favor of `encryption.secret` and will be removed in 2.0. Please note that if you start using `encryption.secret` you also need to set `encryption.provider` to `mcrypt` since mcrypt is not the default when using the `encryption.*` options.
 
 ### Added
 - Added support for custom encryption providers.

--- a/DependencyInjection/JMSPaymentCoreExtension.php
+++ b/DependencyInjection/JMSPaymentCoreExtension.php
@@ -59,9 +59,9 @@ class JMSPaymentCoreExtension extends Extension implements PrependExtensionInter
             }
         } else {
             $container->removeAlias('payment.encryption_service');
+            $container->removeDefinition('payment.encryption');
             $container->removeDefinition('payment.encryption.mcrypt');
             $container->removeDefinition('payment.encryption.defuse_php_encryption');
-            $container->removeDefinition('payment.encryption');
         }
     }
 

--- a/Resources/doc/setup.rst
+++ b/Resources/doc/setup.rst
@@ -31,9 +31,10 @@ You can generate the secret with the following command:
 
 .. code-block :: bash
 
-    # Feel free to increase the length of the generated string by
-    # passing a larger number to openssl_random_pseudo_bytes
-    php -r 'echo bin2hex(openssl_random_pseudo_bytes(16))."\n";'
+    php -r '
+        require "vendor/autoload.php";
+        echo (\Defuse\Crypto\Key::createNewRandomKey())->saveToAsciiSafeString()."\n";
+    '
 
 And then use it in your configuration:
 
@@ -44,9 +45,9 @@ And then use it in your configuration:
         # app/config/config.yml
         jms_payment_core:
             encryption:
-                secret: yoursecret
+                secret: output_of_above_command
 
-.. note ::
+.. warning ::
 
     If you change the secret, all data encrypted with the old secret will become unreadable.
 

--- a/Tests/DependencyInjection/Configuration/ConfigurationTest.php
+++ b/Tests/DependencyInjection/Configuration/ConfigurationTest.php
@@ -16,7 +16,7 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             array(),
             array('encryption' => array(
                 'enabled' => false,
-                'provider' => 'mcrypt',
+                'provider' => 'defuse_php_encryption',
             ))
         );
     }
@@ -47,7 +47,7 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             array(),
             array('encryption' => array(
                 'enabled' => false,
-                'provider' => 'mcrypt',
+                'provider' => 'defuse_php_encryption',
             ))
         );
 
@@ -55,7 +55,7 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             array('encryption' => false),
             array('encryption' => array(
                 'enabled' => false,
-                'provider' => 'mcrypt',
+                'provider' => 'defuse_php_encryption',
             ))
         );
 
@@ -65,7 +65,7 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             )),
             array('encryption' => array(
                 'enabled' => false,
-                'provider' => 'mcrypt',
+                'provider' => 'defuse_php_encryption',
             ))
         );
     }
@@ -83,6 +83,21 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             'secret' => 'foo',
         )));
 
+        $this->assertConfigurationIsValid(array('encryption' => array(
+            'secret' => 'foo',
+        )));
+
+        $this->assertConfigurationEquals(
+            array('encryption' => array(
+                'secret' => 'foo',
+            )),
+            array('encryption' => array(
+                'enabled' => true,
+                'secret' => 'foo',
+                'provider' => 'defuse_php_encryption',
+            ))
+        );
+
         $this->assertConfigurationEquals(
             array('encryption' => array(
                 'enabled' => true,
@@ -91,7 +106,7 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             array('encryption' => array(
                 'enabled' => true,
                 'secret' => 'foo',
-                'provider' => 'mcrypt',
+                'provider' => 'defuse_php_encryption',
             ))
         );
     }


### PR DESCRIPTION
Only applies when using the `encryption.secret` option. If the `secret` configuration option is used, mcrypt will still be the default in order to maintain BC.