### PR TITLE
Fix reverse deposit check

### DIFF
--- a/PluginController/PluginController.php
+++ b/PluginController/PluginController.php
@@ -956,8 +956,11 @@ abstract class PluginController implements PluginControllerInterface
             throw new InvalidPaymentInstructionException('PaymentInstruction must be in STATE_VALID.');
         }
 
-        if (PaymentInterface::STATE_APPROVED !== $payment->getState()) {
-            throw new InvalidPaymentException('Payment must be in STATE_APPROVED.');
+        if (!in_array($payment->getState(), [
+            PaymentInterface::STATE_APPROVED,
+            PaymentInterface::STATE_DEPOSITED,
+        ])) {
+            throw new InvalidPaymentException('Payment must be in STATE_APPROVED or STATE_DEPOSITED.');
         }
 
         $transaction = $instruction->getPendingTransaction();

--- a/PluginController/PluginController.php
+++ b/PluginController/PluginController.php
@@ -986,6 +986,7 @@ abstract class PluginController implements PluginControllerInterface
             $transaction->setTransactionType(FinancialTransactionInterface::TRANSACTION_TYPE_REVERSE_DEPOSIT);
             $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
             $transaction->setRequestedAmount($amount);
+            $payment->addTransaction($transaction);
 
             $payment->setReversingDepositedAmount($amount);
             $instruction->setReversingDepositedAmount($instruction->getReversingDepositedAmount() + $amount);

--- a/PluginController/PluginController.php
+++ b/PluginController/PluginController.php
@@ -429,7 +429,11 @@ abstract class PluginController implements PluginControllerInterface
         }
 
         $paymentState = $payment->getState();
-        if (PaymentInterface::STATE_APPROVED !== $paymentState && PaymentInterface::STATE_EXPIRED !== $paymentState) {
+        if (!in_array($paymentState, [
+                PaymentInterface::STATE_APPROVED,
+                PaymentInterface::STATE_EXPIRED,
+                PaymentInterface::STATE_DEPOSITED,
+        ])) {
             throw new InvalidPaymentException('Payment\'s state must be APPROVED, or EXPIRED.');
         }
 

--- a/PluginController/PluginController.php
+++ b/PluginController/PluginController.php
@@ -474,10 +474,15 @@ abstract class PluginController implements PluginControllerInterface
                 throw new \InvalidArgumentException(sprintf('$amount cannot be greater than %.2f (Credit restriction).', $credit->getTargetAmount()));
             }
 
+            $payment = null;
             if (false === $credit->isIndependent()) {
                 $payment = $credit->getPayment();
                 $paymentState = $payment->getState();
-                if (PaymentInterface::STATE_APPROVED !== $paymentState && PaymentInterface::STATE_EXPIRED !== $paymentState) {
+                if (!in_array($paymentState, [
+                    PaymentInterface::STATE_APPROVED,
+                    PaymentInterface::STATE_DEPOSITED,
+                    PaymentInterface::STATE_EXPIRED,
+                ])) {
                     throw new InvalidPaymentException('Payment\'s state must be APPROVED, or EXPIRED.');
                 }
 

--- a/PluginController/PluginControllerInterface.php
+++ b/PluginController/PluginControllerInterface.php
@@ -496,7 +496,7 @@ interface PluginControllerInterface
      *
      * The implementation will ensure that:
      * - PaymentInstruction is in STATE_VALID
-     * - Payment is in STATE_APPROVED
+     * - Payment is in STATE_APPROVED or STATE_DEPOSITED
      * - any pending transaction is belonging to this payment, and is a reverseDeposit transaction
      * - for non-retry transactions: requested amount <= PaymentInstruction.depositedAmount - PaymentInstruction.reversingDepositedAmount
      * - for non-retry transactions: requested amount <= Payment.depositedAmount


### PR DESCRIPTION
I might haven't understood the correct way to use this bundle but in the current situation it's impossible to reverse deposit as the script check for a status "APPROVED" and refuse "DEPOSITED". So my guess was there were an error.

So I update the PluginController class to accept "DEPOSITED" status for reverseDeposit and doDependentCredit methods.

The reverseDeposit method also didn't add the transaction to the payment as it is on reverseApproval and reverseCredit, so I guessed it was an oversight.